### PR TITLE
Torna os Labels do menu de opções clicáveis

### DIFF
--- a/cs_modules/options_ui/options_ui.html
+++ b/cs_modules/options_ui/options_ui.html
@@ -17,42 +17,42 @@
   <section class="seipp-options">
     <h2 class="seipp-options-subtitle">Quais ferramentas você deseja habilitar?</h2>
 
-    <input type="checkbox" data-type="prazo" />
-    <label>Prazo de atendimento (Incluir a data no texto do marcador no formato "<u>ATE dd/mm/aaaa</u>".)</label><br>
+    <label><input type="checkbox" data-type="prazo" />
+    Prazo de atendimento (Incluir a data no texto do marcador no formato "<u>ATE dd/mm/aaaa</u>".)</label><br>
 
-    <input type="checkbox" data-type="qtddias" />
-    <label>Quantidade de dias (Incluir a data no texto do marcador no formato "<u>dd/mm/aaaa</u>".)</label><br>
+    <label><input type="checkbox" data-type="qtddias" />
+    Quantidade de dias (Incluir a data no texto do marcador no formato "<u>dd/mm/aaaa</u>".)</label><br>
 
-    <input type="checkbox" data-type="chkbloco" />
-    <label>Checagem de blocos de assinatura</label><br>
+    <label><input type="checkbox" data-type="chkbloco" />
+    Checagem de blocos de assinatura</label><br>
 
-    <input type="checkbox" data-type="menususp" />
-    <label>Menu do sistema suspenso (Ficará disponível no logo do SEI no canto esquerdo superior)</label><br>
+    <label><input type="checkbox" data-type="menususp" />
+    Menu do sistema suspenso (Ficará disponível no logo do SEI no canto esquerdo superior)</label><br>
 
-    <input type="checkbox" data-type="exibeinfointeressado" />
-    <label>Exibir Informações do interessado (<strong>Exibe Informações do interessado na árvore de processo.</strong>)</label><br>
+    <label><input type="checkbox" data-type="exibeinfointeressado" />
+    Exibir Informações do interessado (<strong>Exibe Informações do interessado na árvore de processo.</strong>)</label><br>
 
-    <input type="checkbox" data-type="atalhonovodoc" />
-    <label>Exibir atalho para novo documento (<strong>Exibe o atalho na árvore de processo.</strong>)</label><br>
+    <label><input type="checkbox" data-type="atalhonovodoc" />
+    Exibir atalho para novo documento (<strong>Exibe o atalho na árvore de processo.</strong>)</label><br>
 
-    <input type="checkbox" data-type="autopreencher" />
-    <label>ANATEL: Ferramenta de auto preenchimento do andamento do processo ao enviar Correspondência (<strong>Experimental</strong>)</label><br>
+    <label><input type="checkbox" data-type="autopreencher" />
+    ANATEL: Ferramenta de auto preenchimento do andamento do processo ao enviar Correspondência (<strong>Experimental</strong>)</label><br>
 
-    <input type="checkbox" data-type="pontocoresanatel" />
-    <label>ANATEL: Ponto de controle em cores (<strong>Somente para a Anatel</strong>)</label><br>
+    <label><input type="checkbox" data-type="pontocoresanatel" />
+    ANATEL: Ponto de controle em cores (<strong>Somente para a Anatel</strong>)</label><br>
 
-    <input type="checkbox" id="cliquemenos" data-type="cliquemenos" />
-    <label>ANATEL: Clique menos (<strong>Facilidade Experimental para uso somente na Anatel</strong>)</label><br>
+    <label><input type="checkbox" id="cliquemenos" data-type="cliquemenos" />
+    ANATEL: Clique menos (<strong>Facilidade Experimental para uso somente na Anatel</strong>)</label><br>
 
     <div id="divFormato">
       <fieldset>
         <legend>Formato</legend>
 
-        <input type="radio" name="formato" id="rdNato" value="N" checked>
-        <label>Nato-digital</label><br>
+        <label><input type="radio" name="formato" id="rdNato" value="N" checked>
+        Nato-digital</label><br>
 
-        <input type="radio" name="formato" id="rdDigitalizado" value="D">
-        <label>Digitalizado nesta Unidade</label>
+        <label><input type="radio" name="formato" id="rdDigitalizado" value="D">
+        Digitalizado nesta Unidade</label>
 
         <div id="divtipoconferencia">
           <label id="ltipoconferencia">Tipo de Conferência:</label><br>
@@ -71,14 +71,14 @@
       <fieldset id="nivelacesso">
         <legend>Nível de Acesso</legend>
 
-        <input type="radio" name="nivelAcesso" id="rdSigiloso" disabled="disabled" value="S">
-        <label>Sigiloso</label><br>
+        <label><input type="radio" name="nivelAcesso" id="rdSigiloso" disabled="disabled" value="S">
+        Sigiloso</label><br>
 
-        <input type="radio" name="nivelAcesso" id="rdRestrito" value="R">
-        <label>Restrito</label><br>
+        <label><input type="radio" name="nivelAcesso" id="rdRestrito" value="R">
+        Restrito</label><br>
 
-        <input type="radio" name="nivelAcesso" id="rdPublico" value="P" checked>
-        <label>Público</label>
+        <label><input type="radio" name="nivelAcesso" id="rdPublico" value="P" checked>
+        Público</label>
 
         <div id="divhipoteseLegal">
           <label id="lhipoteseLegal">Hipótese Legal (para os casos de documento sigiloso ou restrito):</label><br>
@@ -118,8 +118,8 @@
   <section class="seipp-options">
     <h2 class="seipp-options-subtitle">Notificações?</h2>
 
-    <input type="checkbox" data-type="hidemsgupdate" />
-    <label>Desabilitar notificação de autualização?</label><br>
+    <label><input type="checkbox" data-type="hidemsgupdate" />
+    Desabilitar notificação de autualização?</label><br>
 
   </section>
 </fieldset>


### PR DESCRIPTION
Permite clicar nos Labels no menu de opções para selecionar a opção desejada (checkbox e radio).