### PR TITLE
Aumenta o tamanho máximo da caixa de texto do modelo

### DIFF
--- a/cs_modules/documento_gerar.AumentaTamanho.js
+++ b/cs_modules/documento_gerar.AumentaTamanho.js
@@ -1,0 +1,5 @@
+function AumentaTamanho(BaseName) {
+  /** inicialização do módulo */
+  var mconsole = new __mconsole(BaseName + ".AumentaTamanho");
+  document.getElementById('txtProtocoloDocumentoTextoBase').maxLength = 8;
+}

--- a/cs_modules/documento_gerar.js
+++ b/cs_modules/documento_gerar.js
@@ -1,0 +1,4 @@
+const BaseName = "documento_gerar";
+
+if (ModuleInit(BaseName))
+  AumentaTamanho(BaseName);

--- a/manifest.json
+++ b/manifest.json
@@ -127,6 +127,14 @@
         "cs_modules/infra_configurar.Options_ui.js",
         "cs_modules/infra_configurar.js"
       ]
+    },
+    {
+      "matches": ["*://*.br/sei/controlador.php?acao=documento_gerar*"],
+      "all_frames": true,
+      "js": [
+        "cs_modules/documento_gerar.AumentaTamanho.js",
+        "cs_modules/documento_gerar.js"
+      ]
     }
   ],
 


### PR DESCRIPTION
Aumenta o tamanho máximo da caixa de texto para modelo do documento a ser criado. Na PRF esse número hoje possui 8 algarismos e o campo permite até 7 algarismos. Uma correção está prevista no SEI, mas deve demorar ainda alguns dias para resolver.