### PR TITLE
Confirma antes da conclusão

### DIFF
--- a/cs_modules/procedimento_controlar.ConfirmarAntesConcluir.js
+++ b/cs_modules/procedimento_controlar.ConfirmarAntesConcluir.js
@@ -1,0 +1,14 @@
+function ConfirmarAntesConcluir(BaseName) {
+  /** inicialização do módulo */
+  var mconsole = new __mconsole(BaseName + ".ConfirmarAntesConcluir");
+
+  let botao = document.querySelector('img[src="imagens/sei_concluir_processo.gif"]');
+  if (botao) {
+    let btnFunction = botao.parentElement.onclick;
+    botao.parentElement.onclick = function() {
+      if (confirm('Deseja mesmo concluir os processos selecionados?')) {
+        btnFunction.call();
+      }
+    };
+  }
+}

--- a/cs_modules/procedimento_controlar.js
+++ b/cs_modules/procedimento_controlar.js
@@ -26,4 +26,5 @@ if (ModuleInit(BaseName, true)) {
   }, this);
   AdicionarOrdenacao(BaseName);
   SelecionarMultiplosProcessos(BaseName);
+  ConfirmarAntesConcluir(BaseName);
 }

--- a/manifest.json
+++ b/manifest.json
@@ -61,6 +61,7 @@
       "js": [
         "lib/jquery.tablesorter.min.js", "lib/jquery.tablesorter.widgets.min.js",
         "cs_modules/procedimento_controlar.CorrigirTabelas.js",
+        "cs_modules/procedimento_controlar.ConfirmarAntesConcluir.js",
         "cs_modules/procedimento_controlar.IncluirCalculoPrazos.js",
         "cs_modules/procedimento_controlar.MarcarCorProcesso.js",
         "cs_modules/procedimento_controlar.AdicionarOrdenacao.js",


### PR DESCRIPTION
Emite uma confirmação antes da conclusão dos processos na tela inicial,
evitando assim concluir um processo por engano.

Closes #45