### PR TITLE
Exibir descrição do processo ao invés do número

### DIFF
--- a/cs_modules/core.d_idle.ExibirNomeDoProcesso.js
+++ b/cs_modules/core.d_idle.ExibirNomeDoProcesso.js
@@ -1,6 +1,7 @@
 function ExibirNomeDoProcesso(BaseName) {
   /** inicialização do módulo */
   var mconsole = new __mconsole(BaseName + ".ExibirNomeDoProcesso");
+
   var processos = document.getElementsByClassName("processoVisualizado");
   for (var i = 0; i < processos.length; i++) {
     var p = processos[i];

--- a/cs_modules/core.d_idle.ExibirNomeDoProcesso.js
+++ b/cs_modules/core.d_idle.ExibirNomeDoProcesso.js
@@ -1,12 +1,14 @@
 function ExibirNomeDoProcesso(BaseName) {
   /** inicialização do módulo */
-  var mconsole = new __mconsole(BaseName + ".ExibirNomeDoProcesso");
+  //mconsole.log("entrou1");
+  //var mconsole = new __mconsole(BaseName + ".ExibirNomeDoProcesso");
+  //mconsole.log("entrou2");
 
   var processos = document.getElementsByClassName("processoVisualizado");
   for (var i = 0; i < processos.length; i++) {
     var p = processos[i];
     var text = p.onmouseover+"";
-    var extracted = text.substring(text.lastIndexOf("(")+1,text.lastIndexOf(")"$
+    var extracted = text.substring(text.lastIndexOf("(")+1,text.lastIndexOf(")"));
     extracted = extracted.substring(1, extracted.lastIndexOf(",")-1);
   
     if (extracted.length>0){

--- a/cs_modules/core.d_idle.ExibirNomeDoProcesso.js
+++ b/cs_modules/core.d_idle.ExibirNomeDoProcesso.js
@@ -1,0 +1,15 @@
+function ExibirNomeDoProcesso(BaseName) {
+  /** inicialização do módulo */
+  var mconsole = new __mconsole(BaseName + ".ExibirNomeDoProcesso");
+  var processos = document.getElementsByClassName("processoVisualizado");
+  for (var i = 0; i < processos.length; i++) {
+    var p = processos[i];
+    var text = p.onmouseover+"";
+    var extracted = text.substring(text.lastIndexOf("(")+1,text.lastIndexOf(")"$
+    extracted = extracted.substring(1, extracted.lastIndexOf(",")-1);
+  
+    if (extracted.length>0){
+        p.innerText = extracted;
+    }
+  }
+}

--- a/cs_modules/core.d_idle.js
+++ b/cs_modules/core.d_idle.js
@@ -23,6 +23,7 @@ if (ModuleInit(ModName_idle)) {
         break;
       case "exibirnomedoprocesso":
         ExibirNomeDoProcesso(ModName_idle);
+        break;
       default:
         break;
     }

--- a/cs_modules/core.d_idle.js
+++ b/cs_modules/core.d_idle.js
@@ -21,6 +21,8 @@ if (ModuleInit(ModName_idle)) {
       case "atalhopublicacoeseletronicas":
         AtalhoPublicacoesEletronicas(ModName_idle);
         break;
+      case "exibirnomedoprocesso":
+        ExibirNomeDoProcesso(ModName_idle);
       default:
         break;
     }

--- a/cs_modules/options_ui/options_ui.html
+++ b/cs_modules/options_ui/options_ui.html
@@ -131,6 +131,9 @@
     <label><input type="checkbox" data-type="atalhopublicacoeseletronicas" />
     Exibir link de atalho para Publicações Eletrônicas</label><br>
 
+    <label><input type="checkbox" data-type="exibirnomedoprocesso" />
+    Exibir descrição do processo ao invés do número</label><br>
+
     <label><input type="checkbox" id="cliquemenos" data-type="cliquemenos" />
     Clique menos (<strong>Facilidade Experimental</strong>)</label><br>
 

--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,6 @@
         "cs_modules/core.d_start.lib.js",
         "cs_modules/core.d_start.RedirecionarPagina.js",
         "cs_modules/core.d_start.Theme.js",
-        "cs_modules/core.d_start.ExibirNomeDoProcesso.js",
         "cs_modules/core.d_start.js"
       ]
     },
@@ -46,6 +45,7 @@
         "cs_modules/core.d_idle.VerificarBlocoAssinatura.js",
         "cs_modules/core.d_idle.IndicarConfiguracao.js",
         "cs_modules/core.d_idle.AtalhoPublicacoesEletronicas.js",
+        "cs_modules/core.d_idle.ExibirNomeDoProcesso.js",
         "cs_modules/core.d_idle.js"
       ]
     },

--- a/manifest.json
+++ b/manifest.json
@@ -30,6 +30,7 @@
         "cs_modules/core.d_start.lib.js",
         "cs_modules/core.d_start.RedirecionarPagina.js",
         "cs_modules/core.d_start.Theme.js",
+        "cs_modules/core.d_start.ExibirNomeDoProcesso.js",
         "cs_modules/core.d_start.js"
       ]
     },


### PR DESCRIPTION
Trecho de código que exibe a descrição do processo ao invés do número.
Se não for colocada uma descrição, ele exibe o número do processo.
Testado no Firefox.