### PR TITLE
Correção BUG #97

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -61,6 +61,7 @@
     {
       "matches": ["*://*.br/*controlador.php?acao=procedimento_controlar*"],
       "js": [
+        "lib/jquery.tablesorter.min.js", "lib/jquery.tablesorter.widgets.min.js",
         "cs_modules/procedimento_controlar.CorrigirTabelas.js",
         "cs_modules/procedimento_controlar.ConfirmarAntesConcluir.js",
         "cs_modules/procedimento_controlar.IncluirCalculoPrazos.js",


### PR DESCRIPTION
Com a nova versão da extensão (4.2.3), a funcionalidade de filtrar processos através da barra de pesquisa parou de funcionar.

Com as últimas modificações, a lib `jquery.tablesorter` não era mais injetada através do `manifest.json`, sendo inserida apenas através do método `addScriptToPage`.

Mas, como se verificou, ela era utilizada também por outros módulos (`lib.filtra_processos.PesquisarInformacoes.js`, por exemplo). Desta forma, ela deve continuar ser inserida através do `manifest.json`.

Este PR, portanto, corrige este cenário, restabelecendo a inserção da lib através do `manifest.json`.

Fix #97 
