### PR TITLE
Fix #121 - Correção do bug da tela de configurações

### DIFF
--- a/cs_modules/infra_configurar.Options_ui.js
+++ b/cs_modules/infra_configurar.Options_ui.js
@@ -8,15 +8,17 @@ function Options_ui(BaseName) {
       $("#divInfraBarraComandosSuperior input").hide();
       $(".seipp-options-title").append(" - Versão: " + browser.runtime.getManifest().version);
 
-      browser.storage.local.get("version").then(function (params) {
-        var version = parseInt(params.version);
-        mconsole.log(version)
-        if (version < 68) {
-          $(".seipp-options-title").append("<div id='seipp-div-options-ui-alert' />")
-          $("#seipp-div-options-ui-alert").append("Firefox " + version + " - Você está utilizando uma versão antiga do Firefox, alguns recursos do SEI++ podem não ser compativeis. Atualize o navegador.")
-            .css({ "font-weight": "bold", "color": "red", "filter": "none", "background-color": "black" });
-        }
-      }, null);
+      if (!isChrome) {
+        browser.storage.local.get("version").then(function (params) {
+          var version = parseInt(params.version);
+          mconsole.log(version)
+          if (version < 68) {
+            $(".seipp-options-title").append("<div id='seipp-div-options-ui-alert' />")
+            $("#seipp-div-options-ui-alert").append("Firefox " + version + " - Você está utilizando uma versão antiga do Firefox, alguns recursos do SEI++ podem não ser compativeis. Atualize o navegador.")
+              .css({ "font-weight": "bold", "color": "red", "filter": "none", "background-color": "black" });
+          }
+        }, null);
+      }
 
       $("#divInfraBarraLocalizacao").css({
         "padding-left": "10px",


### PR DESCRIPTION
Código em `infra_configurar.Options_ui.js ` estava usando o `browser.storage.local.get` com uma assinatura não compatível com o Chrome, quebrando o script com um erro e fazendo com que as configurações não aparecessem. Adicionei a checagem de navegador já que era uma lógica envolvendo verificação de versão do Firefox.