### PR TITLE
Título da janela ou aba com informações sobre o processo

### DIFF
--- a/cs_modules/procedimento_visualizar.AlterarTitulo.js
+++ b/cs_modules/procedimento_visualizar.AlterarTitulo.js
@@ -1,0 +1,16 @@
+function AlterarTitulo(BaseName) {
+
+	/** inicialização do módulo ***************************************************/
+	var mconsole = new __mconsole(BaseName + ".AlterarTitulo");
+
+	function alterarTitulo() {
+    const numeroProcessoEl = document.querySelector('.infraArvore > a[target="ifrVisualizacao"] > span.infraArvoreNoSelecionado');
+    if (!numeroProcessoEl) return;
+    const tipo = numeroProcessoEl.getAttribute('title');
+    const numero = numeroProcessoEl.textContent.trim();
+
+    window.parent.document.title = `SEI - ${numero} - ${tipo}`;
+	}
+
+	ExecutarNaArvore(mconsole, alterarTitulo);
+}

--- a/cs_modules/procedimento_visualizar.js
+++ b/cs_modules/procedimento_visualizar.js
@@ -40,5 +40,6 @@ if (ModuleInit(BaseName)) {
     }
   }, this);
   AbrirDocumentoNovaAba(BaseName);
+  AlterarTitulo(BaseName);
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -106,6 +106,7 @@
         "cs_modules/procedimento_visualizar.AbrirDocumentoNovaAba.js",
         "cs_modules/procedimento_visualizar.CopiarLinkInterno.js",
         "cs_modules/procedimento_visualizar.Dropzone.js",
+        "cs_modules/procedimento_visualizar.AlterarTitulo.js",
         "cs_modules/procedimento_visualizar.js"
       ]
     },


### PR DESCRIPTION
Na tela de visualização do processo, o título da aba ou da janela do navegador é alterado para conter o número do processo e seu tipo, no formato `SEI - <número> - <tipo>`.

Feature baseada nas sugestões propostas nas issues #112 e #113.

O título fica truncado, por ser longo, mas quando o usuário passa o mouse por cima, mais partes do texto aparecem, o que já ajuda na navegação, pois o usuário consegue ter uma melhor referência sobre qual processo cada aba se refere.

![Screenshot from 2020-09-21 23-10-32](https://user-images.githubusercontent.com/13292515/93838500-3d13f700-fc60-11ea-9f6c-d91edffc80ff.png)

É uma proposta/primeira versão. Sintam-se à vontade para criticar ou sugerir um novo formato ou outros dados.

Não coloquei como opcional (opção a ser habilitada/desabilitada pelo usuário) por que imagino que seja uma funcionalidade útil a todos. Mas podemos rever.

Testado Chrome e Firefox.