### PR TITLE
Dropzone: correções e melhorias

### DIFF
--- a/cs_modules/procedimento_visualizar.Dropzone.js
+++ b/cs_modules/procedimento_visualizar.Dropzone.js
@@ -93,21 +93,22 @@ Dropzone.ui = (function() {
 		ui.wrapper.appendTo("body");
 
 		window.addEventListener('drop', function(evt) {
-			if (!checkarContemArquivos(evt.dataTransfer)) return;
 			evt.preventDefault();
+			if (!checkarContemArquivos(evt.dataTransfer)) return;
 			mudarIcone('aguarde.gif');
 			mudarProgresso(0);
     		for (var i = 0; i < evt.dataTransfer.files.length; i++) {
-    			Dropzone.jobs.adicionar(evt.dataTransfer.files[i]);
+				Dropzone.jobs.adicionar(evt.dataTransfer.files[i]);
     		}
     		Dropzone.jobs.executar();
 		});
-
+		
 		window.addEventListener('dragover', function(evt) {
 			evt.preventDefault();
 		});  
-
+		
 		window.addEventListener('dragenter', function(evt) {
+			evt.preventDefault();
 			if (!checkarContemArquivos(evt.dataTransfer)) return;
 			ui.wrapper.show();
 		});

--- a/cs_modules/procedimento_visualizar.Dropzone.js
+++ b/cs_modules/procedimento_visualizar.Dropzone.js
@@ -32,7 +32,12 @@ Dropzone.utils = {
 			ret = Math.round(numBytes/1024* 100) / 100 +' Kb';
 		}
 		return ret;
-	}  
+	},
+
+	// encodeURIComponent para ISO-8859-1
+	escapeComponent: function(str) {  
+		return escape(str).replace(/\+/g, '%2B');
+	}	
 };
 
 
@@ -176,7 +181,7 @@ Dropzone.jobs = (function() {
 		/* quando há algum erro */
 		if (jobsComErro.length > 0) {
 			var jobsStr = jobsComErro.map(function(job) { return job.nome; }).join(', ');
-			alert('Ocorreu um erro ao incluir documento externo com o(s) seguinte(s) anexo(s): ' + jobsStr + '.')
+			alert('Ocorreu um erro ao incluir documento externo com o(s) seguinte(s) anexo(s): ' + jobsStr + '. Verifique se o processo encontra-se aberto na unidade.')
 		}
 
 		/* recarrega a página sempre que os jobs terminam, independente se erro ou sucesso */
@@ -416,12 +421,11 @@ Dropzone.http.prototype.passos = {
 				hdnAssuntoIdentificador: '',
 			}
 
-			/* montar post body */
+			/* montar post body */		
 			var postData = '';
 			for (var k in postFields) {
 				if (postData !== '') postData = postData + '&';
-				var valor = encodeURIComponent(postFields[k]);
-				if (k === 'hdnAnexos') valor = valor.replace(/%C2/g,''); /* por alguma razão, esse parâmetro vai mal formado para o servidor */
+				var valor = Dropzone.utils.escapeComponent(postFields[k]);
 				postData = postData + k + '=' + valor;
 			}
 			

--- a/cs_modules/procedimento_visualizar.Dropzone.js
+++ b/cs_modules/procedimento_visualizar.Dropzone.js
@@ -109,7 +109,6 @@ Dropzone.ui = (function() {
 
 		window.addEventListener('dragenter', function(evt) {
 			if (!checkarContemArquivos(evt.dataTransfer)) return;
-			Dropzone.log(evt.dataTransfer.files);
 			ui.wrapper.show();
 		});
 

--- a/cs_modules/procedimento_visualizar.Dropzone.js
+++ b/cs_modules/procedimento_visualizar.Dropzone.js
@@ -71,6 +71,15 @@ Dropzone.ui = (function() {
 	}
 
 
+	function checkarContemArquivos(dataTransfer) {
+		return (
+			dataTransfer &&
+			dataTransfer.files &&
+			dataTransfer.types &&
+			dataTransfer.types.indexOf('Files') > -1
+		);
+	}
+
 	function adicionarDropzone() {
 
 		mudarTexto('Arraste aqui...');
@@ -79,10 +88,10 @@ Dropzone.ui = (function() {
 		ui.wrapper.appendTo("body");
 
 		window.addEventListener('drop', function(evt) {
+			if (!checkarContemArquivos(evt.dataTransfer)) return;
 			evt.preventDefault();
 			mudarIcone('aguarde.gif');
 			mudarProgresso(0);
-			if (!evt.dataTransfer.files || evt.dataTransfer.files.length === 0) return;
     		for (var i = 0; i < evt.dataTransfer.files.length; i++) {
     			Dropzone.jobs.adicionar(evt.dataTransfer.files[i]);
     		}
@@ -94,7 +103,8 @@ Dropzone.ui = (function() {
 		});  
 
 		window.addEventListener('dragenter', function(evt) {
-			if (!evt.dataTransfer || !evt.dataTransfer.files) return;
+			if (!checkarContemArquivos(evt.dataTransfer)) return;
+			Dropzone.log(evt.dataTransfer.files);
 			ui.wrapper.show();
 		});
 


### PR DESCRIPTION
Correções e melhorias na Dropzone:

- Agora o script checa se os elementos que estão sendo arrastados são arquivos. Acontecia de o usuário sem querer arrastar um elemento da página e ser interpretado pelo script como um arquivo que estava sendo submetido para upload. A área de dropzone aparecia e para removê-la, só atualizando a página, causando um transtorno.

- Corrigido o problema da codificação dos arquivos. O nome dos arquivos com acentos estavam sendo inseridos no número (descrição) do anexo com a codificação errada, fazendo com que caracteres estranhos fossem inseridos na descrição e até apareciam erros na hora do upload.

- Mensagem de erro acrescentando a informação para o usuário checar se o processo está aberto na unidade. Não é possível inserir documentos se o processo se encontra concluído.

- Corrigido um bug que aparecia no Chrome quando o usuário tentava arrastar um PDF e o navegador abria o arquivo ao invés de deixar o script submeter para upload. Acontecia quando o arquivo era arrastado para o topo da árvore. Foi inserido um `preventDefault` para desabilitar o comportamento natural do browser naquele iframe quando a funcionalidade estiver habilitada.

Correções testadas Firefox e Chrome.