### PR TITLE
Pequenas correções

### DIFF
--- a/cs_modules/options_ui/options_ui.html
+++ b/cs_modules/options_ui/options_ui.html
@@ -178,6 +178,20 @@
         </label>
         <input class="toggle" type="checkbox" data-type="exibeinfointeressado" />
     </div>
+
+    <div class="container flex-container">
+        <label class="toggle-label">
+          Mostrar mais detalhes dos interessados na árvore
+          <div class="tooltip">
+            ?
+            <span class="tooltiptext">
+              Exibe mais informações (endereço completo) abaixo do nome dos interessados na árvore do processo
+            </span>
+          </div>
+        </label>
+        <input class="toggle" type="checkbox" data-type="mostrardetalhesinteressados" />
+    </div>    
+
     <div class="container flex-container">
         <label class="toggle-label">
             Exibir botão novo documento
@@ -320,19 +334,6 @@
       </div>
     </label>
     <input class="toggle" type="checkbox" data-type="ordenaratribuirprocesso" />
-  </div>
-
-  <div class="container flex-container">
-    <label class="toggle-label">
-      Mostrar detalhes dos interessados na árvore
-      <div class="tooltip">
-        ?
-        <span class="tooltiptext">
-          Exibe mais informações (endereço completo) abaixo do nome dos interessados na árvore do processo
-        </span>
-      </div>
-    </label>
-    <input class="toggle" type="checkbox" data-type="mostrardetalhesinteressados" />
   </div>
 
 </div>

--- a/cs_modules/procedimento_visualizar.DocumentoModelo.js
+++ b/cs_modules/procedimento_visualizar.DocumentoModelo.js
@@ -64,10 +64,14 @@ function DocumentoModelo(BaseName) {
             if (iconeCopiar.attr('src') !== 'imagens/sei_documento_interno.gif') return true; /* filtra apenas os documentos internos */
 
             const docId = linkDocumento.attr('id').substr(6);
+            const botaoId = `seipp-dup${docId}`;
+            
+            /* verifica se o botão já existe */
+            if ($(`img#${botaoId}`).length > 0) return true;
 
             /* cria o ícone de documento modelo */
             const linkModelo = $('<img>', {
-                id: `seipp-dup${docId}`,
+                id: botaoId,
                 title: 'Usar documento como modelo',
                 src: browser.extension.getURL('icons/modelo.png'),
             });


### PR DESCRIPTION
- Correção de bug: mostrava de forma repetida o botão de usar documento como modelo cada vez que uma pasta era aberta. Corrigido.

- Alterada a ordem da opção "Mostrar mais detalhes dos interessados na árvore" para ficar abaixo da "Exibir Informações do interessado" para manter uma coesão, visto que são funcionalidades que dizem respeito ao mesmo assunto.
