### PR TITLE
Adiciona opções para selecionar documentos no Bloco de Assinatura

### DIFF
--- a/cs_modules/core.css
+++ b/cs_modules/core.css
@@ -126,3 +126,21 @@
 .no-image img{
   background-color: white !important;
 }
+
+
+/* CSS for Module: SelecionarDocumentosAssinar*/
+.seipp-selecionar-documentos-assinar {
+  float: left;
+  margin-bottom: 5px;
+}
+
+.seipp-selecionar-documentos-assinar > span {
+  color: #424242;
+  font-size: 12px;
+}
+
+.seipp-selecionar-documentos-assinar > a {
+  color: blue;
+  margin-left: 5px;
+  font-size: 12px;
+}

--- a/cs_modules/core.css
+++ b/cs_modules/core.css
@@ -135,12 +135,24 @@
 }
 
 .seipp-selecionar-documentos-assinar > span {
-  color: #424242;
-  font-size: 12px;
+  color: #9E9E9E;
+  font-size: 11px;
 }
 
 .seipp-selecionar-documentos-assinar > a {
-  color: blue;
-  margin-left: 5px;
-  font-size: 12px;
+  display: inline-block;
+  background-color: #F5F5F5;
+  border-radius: 6px;
+  border: 1px solid #E0E0E0;
+  padding: 2px 6px;
+  color: #757575;
+  margin-left: 3px;
+  font-size: 11px;
+  text-decoration: none;
+  transition: background-color 0.2s ease;
+}
+
+.seipp-selecionar-documentos-assinar > a:hover {
+  text-decoration: none;
+  background-color: #E0E0E0;
 }

--- a/cs_modules/rel_bloco_protocolo_listar.SelecionarDocumentosAssinar.js
+++ b/cs_modules/rel_bloco_protocolo_listar.SelecionarDocumentosAssinar.js
@@ -4,7 +4,7 @@
 
 function SelecionarDocumentosAssinar(BaseName) {
 
-	/** inicialização do módulo ***************************************************/
+  /** inicialização do módulo ***************************************************/
     const mconsole = new __mconsole(BaseName + ".SelecionarDocumentosAssinar");
 
   /* Verifica se o usuário está em um bloco de assinatura */
@@ -27,60 +27,51 @@ function SelecionarDocumentosAssinar(BaseName) {
     assinaturas: tr.querySelectorAll('td')[6].textContent.trim(),
   }));
 
-	const opcoes = document.createElement('div');
+  const opcoes = document.createElement('div');
   opcoes.classList.add('seipp-selecionar-documentos-assinar');
   opcoes.innerHTML = `
     <span>Selecionar:</span>
-    <a href='#' id='btn-selecionar-todos-documentos'>[Todos]</a>
-    <a href='#' id='btn-selecionar-nenhum-documento'>[Nenhum]</a>
-    <a href='#' id='btn-selecionar-documentos-sem-assinatura'>[Sem nenhuma assinatura]</a>
-    <a href='#' id='btn-selecionar-documentos-sem-minha-assinatura'>[Sem a minha assinatura]</a>
-	`;
+    <a href='#' id='btn-selecionar-todos-documentos'>Todos</a>
+    <a href='#' id='btn-selecionar-nenhum-documento'>Nenhum</a>
+    <a href='#' id='btn-selecionar-sem-assinatura'>Sem nenhuma assinatura</a>
+    <a href='#' id='btn-selecionar-sem-minha-assinatura'>Sem a minha assinatura</a>
+    <a href='#' id='btn-selecionar-com-minha-assinatura'>Com a minha assinatura</a>
+  `;
 
   tabela.querySelector('caption.infraCaption').insertAdjacentElement('beforeend', opcoes);
 
-  opcoes.querySelector('#btn-selecionar-todos-documentos').addEventListener('click', (e) => {
-    selecionarTodosDocumentos();
-    e.preventDefault();
-  });
-  
-  opcoes.querySelector('#btn-selecionar-nenhum-documento').addEventListener('click', (e) => {
-    desselecionarTodosDocumentos();
-    e.preventDefault();
-  });
-  
-  opcoes.querySelector('#btn-selecionar-documentos-sem-assinatura').addEventListener('click', (e) => {
-    selecionarSemAssinatura();
-    e.preventDefault();
-  });
+  opcoes.addEventListener('click', (e) => {
+    if (e.target.tagName === 'A') handleClick(e.target.id.replace('btn-selecionar-', ''));
+    e.stopPropagation();
+  }, true)
 
-  opcoes.querySelector('#btn-selecionar-documentos-sem-minha-assinatura').addEventListener('click', (e) => {
-    selecionarSemMinhaAssinatura();
-    e.preventDefault();
-  });
+  const handleClick = (type) => {
+    for (let linha of linhas) {
 
-  const selecionarTodosDocumentos = () => {
-    for (let linha of linhas) {
-      linha.checkbox.checked = true;
-    }
-  }
-  
-  const desselecionarTodosDocumentos = () => {
-    for (let linha of linhas) {
-      linha.checkbox.checked = false;
-    }
-  }
-  
-  const selecionarSemAssinatura = () => {
-    for (let linha of linhas) {
-      linha.checkbox.checked = (linha.assinaturas.length === 0);
-    }
-  }
+      /* seleciona todos documentos */
+      if (type === 'todos-documentos') {
+        linha.checkbox.checked = true;
 
-  const selecionarSemMinhaAssinatura = () => {
-    for (let linha of linhas) {
-      linha.checkbox.checked = !(linha.assinaturas.length > 0 && linha.assinaturas.includes(nomeUsuario));
+      /* desseleciona todos documentos */
+      } else if (type === 'nenhum-documento') {
+        linha.checkbox.checked = false;
+
+      /* seleciona somente os documentos que não possuem assinatura */
+      } else if (type === 'sem-assinatura') {
+        linha.checkbox.checked = (linha.assinaturas.length === 0);
+
+      /* seleciona somente os documentos que não possuem a assinatura do usuário */
+      } else if (type === 'sem-minha-assinatura') {
+        linha.checkbox.checked = !(linha.assinaturas.length > 0 && linha.assinaturas.includes(nomeUsuario));
+
+      /* seleciona somente os documentos que possuem a assinatura do usuário */
+      } else if (type === 'com-minha-assinatura') {
+        linha.checkbox.checked = (linha.assinaturas.length > 0 && linha.assinaturas.includes(nomeUsuario));
+      }
+
+
     }
-  }
+  };
+
 
 }

--- a/cs_modules/rel_bloco_protocolo_listar.SelecionarDocumentosAssinar.js
+++ b/cs_modules/rel_bloco_protocolo_listar.SelecionarDocumentosAssinar.js
@@ -1,0 +1,86 @@
+/**
+ * Dentro de um bloco de assinatura, adiciona opções que auxiliam a selecionar os documentos para assinar
+ */
+
+function SelecionarDocumentosAssinar(BaseName) {
+
+	/** inicialização do módulo ***************************************************/
+    const mconsole = new __mconsole(BaseName + ".SelecionarDocumentosAssinar");
+
+  /* Verifica se o usuário está em um bloco de assinatura */
+  const blocoDeAssinatura = 
+    document.querySelector('#divInfraBarraLocalizacao') &&
+    /Bloco de Assinatura/.test(document.querySelector('#divInfraBarraLocalizacao').textContent) &&
+    document.querySelector('#btnAssinar');
+      
+  
+  if (!blocoDeAssinatura) return;
+
+  /* busca o nome do usuário do cabeçalho */
+  const nomeUsuario = document.querySelector('#lnkUsuarioSistema').getAttribute('title').match(/(.+)\s-\s/)[1];
+
+  /* Adiciona os botões */
+  const tabela = document.querySelector('#divInfraAreaTabela');
+
+  const linhas = [...tabela.querySelectorAll('tbody > tr[id^="trSeq"]')].map((tr) => ({
+    checkbox: tr.querySelector('input[type="checkbox"]'),
+    assinaturas: tr.querySelectorAll('td')[6].textContent.trim(),
+  }));
+
+	const opcoes = document.createElement('div');
+  opcoes.classList.add('seipp-selecionar-documentos-assinar');
+  opcoes.innerHTML = `
+    <span>Selecionar:</span>
+    <a href='#' id='btn-selecionar-todos-documentos'>[Todos]</a>
+    <a href='#' id='btn-selecionar-nenhum-documento'>[Nenhum]</a>
+    <a href='#' id='btn-selecionar-documentos-sem-assinatura'>[Sem nenhuma assinatura]</a>
+    <a href='#' id='btn-selecionar-documentos-sem-minha-assinatura'>[Sem a minha assinatura]</a>
+	`;
+
+  tabela.querySelector('caption.infraCaption').insertAdjacentElement('beforeend', opcoes);
+
+  opcoes.querySelector('#btn-selecionar-todos-documentos').addEventListener('click', (e) => {
+    selecionarTodosDocumentos();
+    e.preventDefault();
+  });
+  
+  opcoes.querySelector('#btn-selecionar-nenhum-documento').addEventListener('click', (e) => {
+    desselecionarTodosDocumentos();
+    e.preventDefault();
+  });
+  
+  opcoes.querySelector('#btn-selecionar-documentos-sem-assinatura').addEventListener('click', (e) => {
+    selecionarSemAssinatura();
+    e.preventDefault();
+  });
+
+  opcoes.querySelector('#btn-selecionar-documentos-sem-minha-assinatura').addEventListener('click', (e) => {
+    selecionarSemMinhaAssinatura();
+    e.preventDefault();
+  });
+
+  const selecionarTodosDocumentos = () => {
+    for (let linha of linhas) {
+      linha.checkbox.checked = true;
+    }
+  }
+  
+  const desselecionarTodosDocumentos = () => {
+    for (let linha of linhas) {
+      linha.checkbox.checked = false;
+    }
+  }
+  
+  const selecionarSemAssinatura = () => {
+    for (let linha of linhas) {
+      linha.checkbox.checked = (linha.assinaturas.length === 0);
+    }
+  }
+
+  const selecionarSemMinhaAssinatura = () => {
+    for (let linha of linhas) {
+      linha.checkbox.checked = !(linha.assinaturas.length > 0 && linha.assinaturas.includes(nomeUsuario));
+    }
+  }
+
+}

--- a/cs_modules/rel_bloco_protocolo_listar.js
+++ b/cs_modules/rel_bloco_protocolo_listar.js
@@ -14,4 +14,5 @@ if (ModuleInit(BaseName, true)) {
     }
   }, this);
   SelecionarMultiplosProcessos(BaseName);
+  SelecionarDocumentosAssinar(BaseName);
 }

--- a/manifest.json
+++ b/manifest.json
@@ -83,6 +83,7 @@
         "cs_modules/lib.filtra_processos.PesquisarInformacoes.js",
         "cs_modules/lib.SelecionarMultiplosProcessos.js",
         "cs_modules/lib.RetirarSobrestamentoReabrirEmBloco.js",
+        "cs_modules/rel_bloco_protocolo_listar.SelecionarDocumentosAssinar.js",
         "cs_modules/rel_bloco_protocolo_listar.js"
       ]
     },


### PR DESCRIPTION
Adiciona um menu superior dentro do bloco de assinatura para facilitar a seleção de documentos para assinar, com opções de (1) selecionar todos documentos, (2) desselecionar todos, (3) selecionar apenas os documentos que não têm assinatura, (4) selecionar apenas os documentos que não possuem assinatura do usuário que está assinando e (5) selecionar apenas os documentos que possuem assinatura do usuário que está assinando.

![Screenshot from 2021-03-14 22-33-38](https://user-images.githubusercontent.com/13292515/111092753-b99fd800-8515-11eb-82ef-1683f4e9b5e9.png)
